### PR TITLE
Add Golazon (example app)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@
 - [Colors App](https://github.com/lukeed/colors-app) - PWA for copying values from popular color palettes. Supports HEX, RGB, and HSL formats.
 - [Tracks](https://github.com/jordic/tracks_preact/) - PWA for tracking things in general. Gdrive Sync.
 - [Hueify](https://github.com/kvartborg/hueify) - Simple controller for your Philips Hue lights.
+- [Golazon](https://github.com/sobstel/golazon) - Football data mnmlist way.
 
 ### Related Libraries
 - [React](https://github.com/facebook/react) - A declarative, efficient, and flexible JavaScript library for building user interfaces.


### PR DESCRIPTION
Repo (with readme): https://github.com/sobstel/golazon

Live: http://golazon.surge.sh/ (actually domain is http://www.golazon.com but DNS might not have caught up yet)