### PR TITLE
Add Wouter — a tiny routing library 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@
 ### Routing
 - [Preact Router](https://github.com/developit/preact-router) - URL router for Preact.
 - [Preact Route Async](https://github.com/mjanssen/preact-route-async) - A (440b gzip) route component that enables async loading of page-components.
+- [Wouter](https://github.com/molefrog/wouter) - A tiny (1KB gzip) router for Preact/React with React Router-like API.
 
 ### Components
 - [Preact Material Components](https://github.com/prateekbh/preact-material-components) - Preact wrapper for "Material Components for the web".


### PR DESCRIPTION
**Repo URL:** http://github.com/molefrog/wouter

**Twitter Username:** @mlfrg

**Description:** Wouter is a tiny customisable 1KB library designed after the React Router API. It provides all routing components like `Route`, `Link`, `Switch` and `Redirect`, works with both Preact and React, has hooks support and supports dynamic segments.
